### PR TITLE
Refresh methods added

### DIFF
--- a/geometry/fiber.js
+++ b/geometry/fiber.js
@@ -15,128 +15,7 @@ function FiberSource(control_points, tangents, scale) {
     scale = 1;
   }
   this.scale = scale;
-   /*
-    When called, coeficients are calculated.
-    This takes the FiberSource instance from control points, and a specified
-    mode to compute the tangents.
-
-       Parameters
-       ----------
-       control_points : ndarray shape (N, 3)
-       tangents : 'incoming', 'outgoing', 'symmetric'
-       scale : multiplication factor.
-           This is useful when the coodinates are given dimensionless, and we
-           want a specific size for the phantom.
-
-
-    The output is the coefficients as f(x)=a0+a1x+a2x^2+a3x^3 for each x, y and
-    z and for each pair of points, as this.xpoly, this.ypoly and this.zpoly.
-    Timestamps normalized in [0,1] are also calculated in this.ts
-  */
-  nb_points = control_points.length;
-  // Take distance of each pair of given control points
-  var distances = [];
-  for (var i = 0; i < nb_points-1; i++) {
-    var squared_distance = 0;
-    for (var j = 0; j < 3; j++) {
-      squared_distance += Math.pow(control_points[i+1][j]-control_points[i][j], 2);
-    }
-    distances[i] = Math.sqrt(squared_distance);
-  }
-  // Make time interval proportional to distance between control points
-  var ts = [0, distances[0]];
-  for (var i = 2; i < nb_points; i++) {
-    ts[i] = ts[i-1]+distances[i-1];
-  }
-  length = ts[ts.length - 1];
-  for (var i = 0; i < nb_points; i++) {
-    ts[i] /= length;
-  }
-
-  //INTERPOLATION
-  // as [x y z] for each point
-  var derivatives = [];
-  // For start and ending points; normal to the surface
-  derivatives[0]=[];
-  derivatives[nb_points-1] = [];
-  for (var i = 0; i < 3; i++) {
-    derivatives[0][i] = -control_points[0][i];
-    derivatives[nb_points-1][i] = control_points[nb_points-1][i];
-  }
-  // As for other derivatives, we use discrete approx
-  switch (tangents) {
-    case "incoming":
-      for (var i = 1; i < nb_points-1; i++) {
-        derivatives[i] = [];
-        for (var j = 0; j < 3; j++) {
-          derivatives[i][j] = control_points[i][j]-control_points[i-1][j];
-        }
-      }
-      break;
-    case "outgoing":
-      for (var i = 1; i < nb_points-1; i++) {
-        derivatives[i]=[];
-        for (var j = 0; j < 3; j++) {
-          derivatives[i][j] = control_points[i+1][j]-control_points[i][j];
-        }
-      }
-      break;
-    case "symmetric":
-      for (var i = 1; i < nb_points-1; i++) {
-        derivatives[i] = [];
-        for (var j = 0; j < 3; j++) {
-          derivatives[i][j] = control_points[i+1][j]-control_points[i-1][j];
-        }
-      }
-      break;
-    default:
-      console.error("'tangents' should be one of the following:\
-        'incoming', 'outgoing', 'symmetric'");
-  }
-  for (var i = 0; i < derivatives.length; i++) {
-    var squared_derivative_norm = 0;
-    for (var j = 0; j < 3; j++) {
-        squared_derivative_norm += Math.pow(derivatives[i][j], 2);
-    }
-    var derivative_vector = [];
-    for (var j = 0; j < 3; j++) {
-        derivative_vector[j] = (derivatives[i][j]
-          /Math.sqrt(squared_derivative_norm))*length;
-    }
-    derivatives[i] = derivative_vector;
-  }
-
-  // RETURN POLYNOMIALS
-  /*Function that returns 4x4 array with polynomials [a,b,c,d] for given ts (t),
-      control points (p) and derivatives (pd).
-      Values of a, b, c and d are found by solving the system
-       (t)= a + b[(t-ti)/(ti1-ti)] + c[(t-ti)/(ti1-ti)]^2 + d[(t-ti)/(ti1-ti)]^3
-      along with its derivative, being ti and ti1 t_i and t_(i+1).
-  */
-  function poly(t, p, pd) {
-    coef = [];
-    for (var i = 0; i < t.length-1; i++) {
-      coef[i] = [p[i],
-              (t[i+1]-t[i]) * pd[i],
-              3*p[i+1] - (t[i+1]-t[i])*pd[i+1] - 2*(t[i+1]-t[i])*pd[i] - 3*p[i],
-              (t[i+1]-t[i])*pd[i+1] - 2*p[i+1] + (t[i+1]-t[i])*pd[i] + 2*p[i]
-      ];
-    }
-    return coef;
-  }
-  // Col extracts columns for matrices as array-of-arrays.
-  function col(matrix, column) {
-    var array = [];
-    for (var i = 0; i < matrix.length; i++) {
-      array[i] = matrix[i][column];
-    }
-    return array;
-  }
-  this.xpoly = poly(ts, col(control_points, 0), col(derivatives, 0));
-  this.ypoly = poly(ts, col(control_points, 1), col(derivatives, 1));
-  this.zpoly = poly(ts, col(control_points, 2), col(derivatives, 2));
-  this.ts = ts;
-  this.length = length;
+  this.polycalc();
 }
 
 /* FiberSource methods definition
@@ -147,6 +26,135 @@ function FiberSource(control_points, tangents, scale) {
   'curvature' outputs the curvature of the trajectory for each timestep given.
 */
 FiberSource.prototype = {
+  polycalc: function() {
+    /*
+     When called, coeficients are calculated.
+     This takes the FiberSource instance from control points, and a specified
+     mode to compute the tangents.
+
+        Parameters
+        ----------
+        control_points : ndarray shape (N, 3)
+        tangents : 'incoming', 'outgoing', 'symmetric'
+        scale : multiplication factor.
+            This is useful when the coodinates are given dimensionless, and we
+            want a specific size for the phantom.
+
+
+     The output is the coefficients as f(x)=a0+a1x+a2x^2+a3x^3 for each x, y and
+     z and for each pair of points, as this.xpoly, this.ypoly and this.zpoly.
+     Timestamps normalized in [0,1] are also calculated in this.ts
+   */
+   // Take distance of each pair of given control points
+    nb_points = this.control_points.length;
+    var distances = [];
+    for (var i = 0; i < nb_points-1; i++) {
+      var squared_distance = 0;
+      for (var j = 0; j < 3; j++) {
+        squared_distance +=
+          Math.pow(this.control_points[i+1][j] - this.control_points[i][j], 2);
+      }
+      distances[i] = Math.sqrt(squared_distance);
+    }
+    // Make time interval proportional to distance between control points
+    var ts = [0, distances[0]];
+    for (var i = 2; i < nb_points; i++) {
+      ts[i] = ts[i-1]+distances[i-1];
+    }
+    length = ts[ts.length - 1];
+    for (var i = 0; i < nb_points; i++) {
+      ts[i] /= length;
+    }
+
+    //INTERPOLATION
+    // as [x y z] for each point
+    var derivatives = [];
+    // For start and ending points; normal to the surface
+    derivatives[0]=[];
+    derivatives[nb_points-1] = [];
+    for (var i = 0; i < 3; i++) {
+      derivatives[0][i] = -this.control_points[0][i];
+      derivatives[nb_points-1][i] = this.control_points[nb_points-1][i];
+    }
+    // As for other derivatives, we use discrete approx
+    switch (this.tangents) {
+      case "incoming":
+        for (var i = 1; i < nb_points-1; i++) {
+          derivatives[i] = [];
+          for (var j = 0; j < 3; j++) {
+            derivatives[i][j] =
+              this.control_points[i][j] - this.control_points[i-1][j];
+          }
+        }
+        break;
+      case "outgoing":
+        for (var i = 1; i < nb_points-1; i++) {
+          derivatives[i]=[];
+          for (var j = 0; j < 3; j++) {
+            derivatives[i][j] =
+              this.control_points[i+1][j] - this.control_points[i][j];
+          }
+        }
+        break;
+      case "symmetric":
+        for (var i = 1; i < nb_points-1; i++) {
+          derivatives[i] = [];
+          for (var j = 0; j < 3; j++) {
+            derivatives[i][j] =
+              this.control_points[i+1][j] - this.control_points[i-1][j];
+          }
+        }
+        break;
+      default:
+        console.error("'tangents' should be one of the following:\
+          'incoming', 'outgoing', 'symmetric'");
+    }
+    for (var i = 0; i < derivatives.length; i++) {
+      var squared_derivative_norm = 0;
+      for (var j = 0; j < 3; j++) {
+          squared_derivative_norm += Math.pow(derivatives[i][j], 2);
+      }
+      var derivative_vector = [];
+      for (var j = 0; j < 3; j++) {
+          derivative_vector[j] = (derivatives[i][j]
+            /Math.sqrt(squared_derivative_norm))*length;
+      }
+      derivatives[i] = derivative_vector;
+    }
+
+    // RETURN POLYNOMIALS
+    /*Function that returns 4x4 array with polynomials [a,b,c,d] for given ts (t),
+        control points (p) and derivatives (pd).
+        Values of a, b, c and d are found by solving the system
+         (t)= a + b[(t-ti)/(ti1-ti)] + c[(t-ti)/(ti1-ti)]^2 + d[(t-ti)/(ti1-ti)]^3
+        along with its derivative, being ti and ti1 t_i and t_(i+1).
+    */
+    function poly(t, p, pd) {
+      coef = [];
+      for (var i = 0; i < t.length-1; i++) {
+        coef[i] = [p[i],
+                (t[i+1]-t[i]) * pd[i],
+                3*p[i+1] - (t[i+1]-t[i])*pd[i+1] - 2*(t[i+1]-t[i])*pd[i] - 3*p[i],
+                (t[i+1]-t[i])*pd[i+1] - 2*p[i+1] + (t[i+1]-t[i])*pd[i] + 2*p[i]
+        ];
+      }
+      return coef;
+    }
+    // Col extracts columns for matrices as array-of-arrays.
+    function col(matrix, column) {
+      var array = [];
+      for (var i = 0; i < matrix.length; i++) {
+        array[i] = matrix[i][column];
+      }
+      return array;
+    }
+    this.xpoly = poly(ts, col(this.control_points, 0), col(derivatives, 0));
+    this.ypoly = poly(ts, col(this.control_points, 1), col(derivatives, 1));
+    this.zpoly = poly(ts, col(this.control_points, 2), col(derivatives, 2));
+    this.ts = ts;
+    this.length = length;
+  },
+
   interpolate: function(ts) {
   /*
   From a ``FiberSource``, which is a continuous representation, to a
@@ -202,4 +210,33 @@ FiberSource.prototype = {
     }
       return trajectory;
   }
+
+  // recalc: function(control_point) {
+  //   function poly(t, p, pd) {
+  //     coef = [];
+  //     for (var i = 0; i < t.length-1; i++) {
+  //       coef[i] = [p[i],
+  //               (t[i+1]-t[i]) * pd[i],
+  //               3*p[i+1] - (t[i+1]-t[i])*pd[i+1] - 2*(t[i+1]-t[i])*pd[i] - 3*p[i],
+  //               (t[i+1]-t[i])*pd[i+1] - 2*p[i+1] + (t[i+1]-t[i])*pd[i] + 2*p[i]
+  //       ];
+  //     }
+  //     return coef;
+  //   }
+  //   // Col extracts columns for matrices as array-of-arrays.
+  //   function col(matrix, column) {
+  //     var array = [];
+  //     for (var i = 0; i < matrix.length; i++) {
+  //       array[i] = matrix[i][column];
+  //     }
+  //     return array;
+  //   }
+  //   for (var i = control_point-2; i < control_point+3; i++) {
+  //     this.xpoly[i] = poly([this.ts[i],this.ts[i+1]],
+  //                          [this.control_points[i][0],this.control_points[i+1][0],
+  //                          col(derivatives, 0));
+  //     this.ypoly[i] = poly(ts, col(control_points, 1), col(derivatives, 1));
+  //     this.zpoly[i] = poly(ts, col(control_points, 2), col(derivatives, 2));
+  //   }
+  // }
 }

--- a/geometry/fiber.js
+++ b/geometry/fiber.js
@@ -1,8 +1,16 @@
 /*
 This module contains the definition of ``FiberSource``, which is a continuous
 representation of a fiber. All the fibers created are supposed to connect two
-cortical areas. Currently, the only supported shape for the "cortical surface"
-is a sphere.
+cortical areas.
+
+Parameters
+----------
+control_points : array-of-arrays shape (N, 3)
+tangents : 'incoming', 'outgoing', 'symmetric'
+scale : multiplication factor.
+    This is useful when the coodinates are given dimensionless, and we
+    want a specific size for the phantom.
+
 */
 function FiberSource(control_points, tangents, scale) {
   // Initialize properties. By default tangents = 'symmetric', scale = 1.
@@ -15,31 +23,24 @@ function FiberSource(control_points, tangents, scale) {
     scale = 1;
   }
   this.scale = scale;
+
+  // Calculate coefficients
   this.polycalc();
 }
 
 /* FiberSource methods definition
+  'polycalc' calculates coefficients for each polynomial. Needed in constructor
+    and once any of the three FiberSource input change.
   'interpolate' goes from the continuous representation of FiberSource to a
   discretization to given timesteps (ts) between 0 and 1.
   Return is an array which lists [x y z] for each timestep.
-  'tangent' outputs normalized derivative as an [x y z] vector for each timestep.
-  'curvature' outputs the curvature of the trajectory for each timestep given.
 */
 FiberSource.prototype = {
   polycalc: function() {
     /*
-     When called, coeficients are calculated.
+     When called, coefficients are calculated.
      This takes the FiberSource instance from control points, and a specified
      mode to compute the tangents.
-
-        Parameters
-        ----------
-        control_points : ndarray shape (N, 3)
-        tangents : 'incoming', 'outgoing', 'symmetric'
-        scale : multiplication factor.
-            This is useful when the coodinates are given dimensionless, and we
-            want a specific size for the phantom.
-
 
      The output is the coefficients as f(x)=a0+a1x+a2x^2+a3x^3 for each x, y and
      z and for each pair of points, as this.xpoly, this.ypoly and this.zpoly.

--- a/scratch/js/CustomFiber.js
+++ b/scratch/js/CustomFiber.js
@@ -53,7 +53,8 @@ function FiberSkeleton(fiber) {
   var surface = new THREE.MeshBasicMaterial( {color: 0xffff00} );
   this.spheres = new THREE.Mesh(sphereGeometry, surface);
 }
-FiberSkeleton.prototype.constructor = FiberSkeleton;
+
+
 
 /* FiberTube creates a 3D representation of a given fiber in a tubular form
  of given radius.
@@ -92,5 +93,9 @@ function FiberTube(fiber, radius) {
     { color:colors[Math.floor(Math.random()*colors.length)],
                                                 shading: THREE.FlatShading } );
   this.mesh = new THREE.Mesh(geometry, material);
+
 }
-FiberSkeleton.prototype.constructor = FiberTube;
+FiberTube.prototype.refresh = function() {
+  this.mesh.geometry = new THREE.TubeGeometry(this.curve,
+                            this.segments[0], this.radius, this.segments[1]);
+}

--- a/scratch/js/CustomFiber.js
+++ b/scratch/js/CustomFiber.js
@@ -21,6 +21,10 @@ colors = [0xFF1E00, 0xFFB300, 0x1533AD, 0x00BF32, 0xBF4030,
     .fiber - The fiber from which the representation constructed (FiberSource)
     .segments - The amount of length segments in which the fiber is divided
         for representation. By default, 1.5 times the length of the fiber.
+
+  Methods:
+    .refresh - Updates meshes after fiber change. No input no output.
+
 */
 var color = colors[Math.floor(Math.random()*colors.length)];
 function FiberSkeleton(fiber) {
@@ -54,6 +58,30 @@ function FiberSkeleton(fiber) {
   this.spheres = new THREE.Mesh(sphereGeometry, surface);
 }
 
+FiberSkeleton.prototype.refresh = function() {
+  var sphere = new THREE.SphereGeometry( .4 * this.fiber.scale, 32, 32 );
+  var sphereGeometry = new THREE.Geometry();
+  var meshes = [];
+  for (var i = 0; i < points.length; i++) {
+    meshes[i] = new THREE.Mesh(sphere);
+    meshes[i].position.set(points[i][0] * this.fiber.scale,
+              points[i][1] * this.fiber.scale, points[i][2] * this.fiber.scale);
+    meshes[i].updateMatrix();
+    sphereGeometry.merge(meshes[i].geometry, meshes[i].matrix);
+  }
+  this.spheres.geometry = sphereGeometry;
+
+  var discrete_points = new Float32Array(3*this.segments+3);
+  for (var i = 0; i <= this.segments; i++) {
+    discrete_points.set([this.fiber.interpolate(i/this.segments)[0][0],
+                         this.fiber.interpolate(i/this.segments)[0][1],
+                         this.fiber.interpolate(i/this.segments)[0][2]], 3*i);
+  }
+  var trajectory = new THREE.BufferGeometry();
+  trajectory.addAttribute('position',
+                            new THREE.BufferAttribute(discrete_points, 3));
+  this.line.geometry = trajectory;
+}
 
 
 /* FiberTube creates a 3D representation of a given fiber in a tubular form
@@ -72,6 +100,9 @@ function FiberSkeleton(fiber) {
               for representation. By default, 3 times the length of the fiber.
             [1]: The amount of radius segments in which the tube is divided
               for representation. By default, 64.
+
+  Methods:
+   .refresh - Updates mesh after fiber change. No input no output.
  */
 function FiberTube(fiber, radius) {
   this.fiber = fiber;

--- a/scratch/js/animate.js
+++ b/scratch/js/animate.js
@@ -46,10 +46,10 @@ function init() {
 
   // Add the fiber and position camera
   var fiber = new FiberSource(randomPoints(5));
-  // var skeleton = new FiberSkeleton(fiber);
-  // scene.add(skeleton.line, skeleton.spheres)
-  var tube = new FiberTube(fiber);
-  scene.add(tube.mesh);
+  var skeleton = new FiberSkeleton(fiber);
+  scene.add(skeleton.line, skeleton.spheres)
+  // var tube = new FiberTube(fiber);
+  // scene.add(tube.mesh);
   camera.position.set(0, 0, 40 * fiber.scale);
 
   window.addEventListener( 'keypress', movePoint, false );
@@ -57,11 +57,8 @@ function init() {
     fiber.control_points[2] = [fiber.control_points[2][0]+.25,
                                fiber.control_points[2][1]+.25,
                                fiber.control_points[2][2]+.25];
-    // scene.remove(skeleton.line, skeleton.spheres)
-    // fiber = new FiberSource(fiber.control_points);
-    // skeleton = new FiberSkeleton(fiber)
-    // scene.add(skeleton.line, skeleton.spheres)
     fiber.polycalc();
+    skeleton.refresh();
     tube.refresh();
     render();
   }

--- a/scratch/js/animate.js
+++ b/scratch/js/animate.js
@@ -46,9 +46,10 @@ function init() {
 
   // Add the fiber and position camera
   var fiber = new FiberSource(randomPoints(5));
-  var skeleton = new FiberSkeleton(fiber);
-  scene.add(skeleton.line, skeleton.spheres)
+  // var skeleton = new FiberSkeleton(fiber);
+  // scene.add(skeleton.line, skeleton.spheres)
   var tube = new FiberTube(fiber);
+  scene.add(tube.mesh);
   camera.position.set(0, 0, 40 * fiber.scale);
 
   window.addEventListener( 'keypress', movePoint, false );
@@ -56,10 +57,12 @@ function init() {
     fiber.control_points[2] = [fiber.control_points[2][0]+.25,
                                fiber.control_points[2][1]+.25,
                                fiber.control_points[2][2]+.25];
-    scene.remove(skeleton.line, skeleton.spheres)
-    fiber = new FiberSource(fiber.control_points);
-    skeleton = new FiberSkeleton(fiber)
-    scene.add(skeleton.line, skeleton.spheres)
+    // scene.remove(skeleton.line, skeleton.spheres)
+    // fiber = new FiberSource(fiber.control_points);
+    // skeleton = new FiberSkeleton(fiber)
+    // scene.add(skeleton.line, skeleton.spheres)
+    fiber.polycalc();
+    tube.refresh();
     render();
   }
 

--- a/scratch/js/animate.js
+++ b/scratch/js/animate.js
@@ -58,7 +58,7 @@ function init() {
                                fiber.control_points[2][1]+.25,
                                fiber.control_points[2][2]+.25];
     fiber.polycalc();
-    skeleton.refresh();
+    // skeleton.refresh();
     tube.refresh();
     render();
   }


### PR DESCRIPTION
Now, after any change coefficients in a FiberSource may be updated with .polycalc(). 
As well, meshes for FiberSkeleton and FiberTube may be updated with .refresh() (and posterior .render())
KeyPress when showing a fiber for changing one point position is still enabled.

.polycalc() recalculates all coefficients. It is as well called at the constructor. That is due to have been proved that all coefficients change when one point changes, due to timestamps being relative to distance between points.

.refresh() for FiberSkeleton and FiberTube replace the geometry in the mesh for a new one with the FiberSource characteristics.