### PR TITLE
FiberSource.SetControlPoint(n, x, y, z)

### DIFF
--- a/geometry/fiber.js
+++ b/geometry/fiber.js
@@ -26,6 +26,9 @@ function FiberSource(control_points, tangents, scale) {
 
   // Calculate coefficients
   this.polycalc();
+
+  // FiberSource objects will act as subjects to FiberTube or FiberSkeleton
+  this.observers = [];
 }
 
 /* FiberSource methods definition
@@ -211,8 +214,21 @@ FiberSource.prototype = {
     }
       return trajectory;
   },
+  // Pushes an object to the observer list. Once added, will be notified.
+  AddObserver: function(object) {
+    this.observers.push(object)
+  },
+  // Refreshes objects in the observer list
+  notify: function() {
+    for(var i = 0; i < this.observers.length; i++) {
+      this.observers[i].refresh();
+    }
+  },
+  // SetControlPoint changes a control point for this Fiber.
+  // inputs: n (position in control_points array) and x, y, z coordinates.
   SetControlPoint: function(n, x, y, z) {
     this.control_points[n] = [x, y, z];
+    this.polycalc();
+    this.notify();
   }
-
 }

--- a/geometry/fiber.js
+++ b/geometry/fiber.js
@@ -210,34 +210,9 @@ FiberSource.prototype = {
       }
     }
       return trajectory;
+  },
+  SetControlPoint: function(n, x, y, z) {
+    this.control_points[n] = [x, y, z];
   }
 
-  // recalc: function(control_point) {
-  //   function poly(t, p, pd) {
-  //     coef = [];
-  //     for (var i = 0; i < t.length-1; i++) {
-  //       coef[i] = [p[i],
-  //               (t[i+1]-t[i]) * pd[i],
-  //               3*p[i+1] - (t[i+1]-t[i])*pd[i+1] - 2*(t[i+1]-t[i])*pd[i] - 3*p[i],
-  //               (t[i+1]-t[i])*pd[i+1] - 2*p[i+1] + (t[i+1]-t[i])*pd[i] + 2*p[i]
-  //       ];
-  //     }
-  //     return coef;
-  //   }
-  //   // Col extracts columns for matrices as array-of-arrays.
-  //   function col(matrix, column) {
-  //     var array = [];
-  //     for (var i = 0; i < matrix.length; i++) {
-  //       array[i] = matrix[i][column];
-  //     }
-  //     return array;
-  //   }
-  //   for (var i = control_point-2; i < control_point+3; i++) {
-  //     this.xpoly[i] = poly([this.ts[i],this.ts[i+1]],
-  //                          [this.control_points[i][0],this.control_points[i+1][0],
-  //                          col(derivatives, 0));
-  //     this.ypoly[i] = poly(ts, col(control_points, 1), col(derivatives, 1));
-  //     this.zpoly[i] = poly(ts, col(control_points, 2), col(derivatives, 2));
-  //   }
-  // }
 }

--- a/scratch/js/CustomFiber.js
+++ b/scratch/js/CustomFiber.js
@@ -95,11 +95,8 @@ FiberSkeleton.prototype.refresh = function() {
  Other properties:
    .fiber - The fiber from which the representation constructed (FiberSource)
    .curve - THREE.Curve object used for representation
-   .segments - Array of two scalars:
-            [0]: The amount of length segments in which the fiber is divided
-              for representation. By default, 3 times the length of the fiber.
-            [1]: The amount of radius segments in which the tube is divided
-              for representation. By default, 64.
+   .axialSegments and .radialSegments: The segments that make up the tube in
+      each dimension. Default is 256 and 64.
 
   Methods:
    .refresh - Updates mesh after fiber change. No input no output.
@@ -113,13 +110,14 @@ function FiberTube(fiber, radius) {
       var tz = fiber.interpolate(t)[0][2];
   return new THREE.Vector3(tx, ty, tz);
   }
-  this.segments = [Math.floor(fiber.length*3), 64];
+  this.axialSegments = 256;
+  this.radialSegments = 64;
   if (radius === undefined) {
     radius = .5;
   }
   this.radius = radius;
   var geometry = new THREE.TubeGeometry(this.curve,
-                            this.segments[0], this.radius, this.segments[1]);
+                        this.axialSegments , this.radius, this.radialSegments);
   var material = new THREE.MeshPhongMaterial(
     { color:colors[Math.floor(Math.random()*colors.length)],
                                                 shading: THREE.FlatShading } );
@@ -128,5 +126,5 @@ function FiberTube(fiber, radius) {
 }
 FiberTube.prototype.refresh = function() {
   this.mesh.geometry = new THREE.TubeGeometry(this.curve,
-                            this.segments[0], this.radius, this.segments[1]);
+                        this.axialSegments , this.radius, this.radialSegments);
 }

--- a/scratch/js/animate.js
+++ b/scratch/js/animate.js
@@ -59,7 +59,7 @@ function init() {
                                fiber.control_points[2][2]+.25];
     fiber.polycalc();
     skeleton.refresh();
-    tube.refresh();
+    // tube.refresh();
     render();
   }
 

--- a/scratch/js/animate.js
+++ b/scratch/js/animate.js
@@ -46,20 +46,19 @@ function init() {
 
   // Add the fiber and position camera
   var fiber = new FiberSource(randomPoints(5));
-  var skeleton = new FiberSkeleton(fiber);
-  scene.add(skeleton.line, skeleton.spheres)
-  // var tube = new FiberTube(fiber);
-  // scene.add(tube.mesh);
+  // var skeleton = new FiberSkeleton(fiber);
+  // fiber.AddObserver(skeleton);
+  // scene.add(skeleton.line, skeleton.spheres)
+  var tube = new FiberTube(fiber);
+  fiber.AddObserver(tube);
+  scene.add(tube.mesh);
   camera.position.set(0, 0, 40 * fiber.scale);
 
   window.addEventListener( 'keypress', movePoint, false );
   function movePoint() {
-    fiber.control_points[2] = [fiber.control_points[2][0]+.25,
-                               fiber.control_points[2][1]+.25,
-                               fiber.control_points[2][2]+.25];
-    fiber.polycalc();
-    skeleton.refresh();
-    // tube.refresh();
+    fiber.SetControlPoint(2, fiber.control_points[2][0]+.25,
+                             fiber.control_points[2][1]+.25,
+                             fiber.control_points[2][2]+.25);
     render();
   }
 


### PR DESCRIPTION
New method that changes a control point in a FiberSource object.
Added observer design pattern and implemented so with fiber.SetControlPoint(); every mesh involved gets automatically refreshed.
Removed .segments in FiberTube for resolution and replaced with .axialResolution and .radialResolution with defaults 256 and 64. If changed, refresh with .refresh().